### PR TITLE
同一ページ内での複数利用をサポート

### DIFF
--- a/gitlab_issues.inc.php
+++ b/gitlab_issues.inc.php
@@ -27,7 +27,7 @@ document.addEventListener('DOMContentLoaded', async () => {
 });
 
 async function getIssues(domain, project_id) {
-  const url = 'https://' + domain + '/api/v4/projects/' + project_id + '/issues?order_by=updated_at';
+  const url = `https://${domain}/api/v4/projects/${project_id}/issues?order_by=updated_at`;
   const options = { headers: { Authorization: `Bearer $api_token` }};
   const res = await fetch(url, options);
   const issues = await res.json();

--- a/gitlab_issues.inc.php
+++ b/gitlab_issues.inc.php
@@ -20,14 +20,14 @@ import domify from 'https://cdn.pika.dev/domify@1.4.1';
 import dayjs from 'https://cdn.pika.dev/dayjs@1.11.6';
 
 document.addEventListener('DOMContentLoaded', async () => {
-  const issues = (await getIssues()).slice(0, $limit);
+  const issues = (await getIssues('$domain', '$project_id')).slice(0, $limit);
   const issuesTableDOM = makeIssuesTableDOM(issues);
-  document.querySelector('#gitlab-issues-placeholder').appendChild(domify(issuesTableDOM));
-  document.querySelector('#gitlab-issues-loading').style = 'display: none;';
+  document.querySelector('#gitlab-issues-placeholder-$project_id').appendChild(domify(issuesTableDOM));
+  document.querySelector('#gitlab-issues-loading-$project_id').style = 'display: none;';
 });
 
-async function getIssues() {
-  const url = 'https://$domain/api/v4/projects/$project_id/issues?order_by=updated_at';
+async function getIssues(domain, project_id) {
+  const url = 'https://' + domain + '/api/v4/projects/' + project_id + '/issues?order_by=updated_at';
   const options = { headers: { Authorization: `Bearer $api_token` }};
   const res = await fetch(url, options);
   const issues = await res.json();
@@ -114,8 +114,8 @@ function formatDateTime(datetime) {
 }
 EOC;
 
-    return '<div id="gitlab-issues-placeholder"></div>' .
-    '<div id="gitlab-issues-loading">&#9203; Loading GitLab issues...</div>' .
+    return '<div id="gitlab-issues-placeholder-' . $project_id . '"></div>' .
+    '<div id="gitlab-issues-loading-' . $project_id . '">&#9203; Loading GitLab issues...</div>' .
     '<script type="module">' . $js_code . '</script>';
 }
 ?>

--- a/gitlab_issues.inc.php
+++ b/gitlab_issues.inc.php
@@ -27,7 +27,7 @@ document.addEventListener('DOMContentLoaded', async () => {
 });
 
 async function getIssues(domain, project_id) {
-  const url = `https://${domain}/api/v4/projects/${project_id}/issues?order_by=updated_at`;
+  const url = `https://\${domain}/api/v4/projects/\${project_id}/issues?order_by=updated_at`;
   const options = { headers: { Authorization: `Bearer $api_token` }};
   const res = await fetch(url, options);
   const issues = await res.json();


### PR DESCRIPTION
現在、同一ページ内で複数回`#gitlab_issues()`を呼び出すと、全て最も最後の指定のみ正常に動作し、それ以外は不安定な挙動になります。
これはタグのidが衝突しているのが原因のため、毎回異なるidを生成するようにしました。
pukiwikiにインストールし正常動作することを確認しています。